### PR TITLE
add australian state zip codes

### DIFF
--- a/resources/states/AU.json
+++ b/resources/states/AU.json
@@ -8,7 +8,10 @@
         },
         "long": {
             "default": "Western Australia"
-        }
+        },
+        "zip_ranges": [
+            "/^6\\d{3}$/"
+        ]
     },
     {
         "parent": "AU",
@@ -19,7 +22,10 @@
         },
         "long": {
             "default": "South Australia"
-        }
+        },
+        "zip_ranges": [
+            "/^5\\d{3}$/"
+        ]
     },
     {
         "parent": "AU",
@@ -30,7 +36,10 @@
         },
         "long": {
             "default": "Northern Territory"
-        }
+        },
+        "zip_ranges": [
+            "/^0{0,1}(8|9)\\d{2}$/"
+        ]
     },
     {
         "parent": "AU",
@@ -41,7 +50,10 @@
         },
         "long": {
             "default": "Victoria"
-        }
+        },
+        "zip_ranges": [
+            "/^(3|8)\\d{3}$/"
+        ]
     },
     {
         "parent": "AU",
@@ -52,7 +64,10 @@
         },
         "long": {
             "default": "Tasmania"
-        }
+        },
+        "zip_ranges": [
+            "/^7\\d{3}$/"
+        ]
     },
     {
         "parent": "AU",
@@ -63,7 +78,10 @@
         },
         "long": {
             "default": "Queensland"
-        }
+        },
+        "zip_ranges": [
+            "/^(4|9)\\d{3}$/"
+        ]
     },
     {
         "parent": "AU",
@@ -74,7 +92,13 @@
         },
         "long": {
             "default": "New South Wales"
-        }
+        },
+        "zip_ranges": [
+            "/^1\\d{3}$/",
+            "/^2[0-5]\\d{2}$/",
+            "/^(2619)|(2[6-8]\\d{2})$/",
+            "/^(292[1-9])|(29[3-9]\\d{1})$/"
+        ]
     },
     {
         "parent": "AU",
@@ -85,6 +109,11 @@
         },
         "long": {
             "default": "Australian Capital Territory"
-        }
+        },
+        "zip_ranges": [
+            "/^0{0,1}2\\d{2}$/",
+            "/^(260\\d)|(261[0-8])$/",
+            "/^(29[0-1]\\d)|(2920)$/"
+        ]
     }
 ]

--- a/resources/states/AU.json
+++ b/resources/states/AU.json
@@ -9,7 +9,7 @@
         "long": {
             "default": "Western Australia"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^6\\d{3}$/"
         ]
     },
@@ -23,7 +23,7 @@
         "long": {
             "default": "South Australia"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^5\\d{3}$/"
         ]
     },
@@ -37,7 +37,7 @@
         "long": {
             "default": "Northern Territory"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^0{0,1}(8|9)\\d{2}$/"
         ]
     },
@@ -51,7 +51,7 @@
         "long": {
             "default": "Victoria"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^(3|8)\\d{3}$/"
         ]
     },
@@ -65,7 +65,7 @@
         "long": {
             "default": "Tasmania"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^7\\d{3}$/"
         ]
     },
@@ -79,7 +79,7 @@
         "long": {
             "default": "Queensland"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^(4|9)\\d{3}$/"
         ]
     },
@@ -93,7 +93,7 @@
         "long": {
             "default": "New South Wales"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^1\\d{3}$/",
             "/^2[0-5]\\d{2}$/",
             "/^(2619)|(2[6-8]\\d{2})$/",
@@ -110,7 +110,7 @@
         "long": {
             "default": "Australian Capital Territory"
         },
-        "zip_ranges": [
+        "postcodes": [
             "/^0{0,1}2\\d{2}$/",
             "/^(260\\d)|(261[0-8])$/",
             "/^(29[0-1]\\d)|(2920)$/"


### PR DESCRIPTION
Adding zip / postcode regexes to Australian states.

**New South Wales**

1000—1999 (LVRs and PO Boxes only)
2000—2599 (includes Norfolk Island)
2619—2899
2921—2999

**Australian Capital Territory**

0200—0299 (LVRs and PO Boxes only)
2600—2618
2900—2920

**Victoria**

3000—3999
8000—8999 (LVRs and PO Boxes only)

**Queensland**

4000—4999
9000—9999 (LVRs and PO Boxes only)

**South Australia**

5000—5799
5800—5999 (LVRs and PO Boxes only)

**Western Australia**

6000—6797
6798 (Christmas Island)
6799 (Cocos (Keeling) Islands)
6800—6999 (LVRs and PO Boxes only)

**Tasmania**

7000—7799
7800—7999 (LVRs and PO Boxes only)

**Northern Territory**

0800—0899
0900—0999 (LVRs and PO Boxes only)

src: https://en.wikipedia.org/wiki/Postcodes_in_Australia#Allocation