### PR TITLE
Updating missing phone prefixes

### DIFF
--- a/resources/countries.json
+++ b/resources/countries.json
@@ -239,6 +239,7 @@
       "default": "Antarctica"
     },
     "area": 14000000,
+    "phone": "672",
     "continent": "AN"
   },
   {
@@ -748,6 +749,7 @@
     },
     "area": 49,
     "currency": "NOK",
+    "phone": "47",
     "continent": "AN"
   },
   {
@@ -1838,6 +1840,7 @@
     },
     "area": 7829,
     "currency": "EUR",
+    "phone": "262",
     "continent": "AN",
     "population": 140
   },
@@ -4661,6 +4664,7 @@
     },
     "area": 3903,
     "currency": "GBP",
+    "phone": "500",
     "continent": "AN",
     "population": 30
   },


### PR DESCRIPTION
Here you can find the sources:

**Anctartica**
https://countrycode.org/antarctica
http://www.country-dialing-codes.net/Antarctica/

**French Southern Territories**
http://www.country-dialing-codes.net/French-Southern-Territories/
http://happyzebra.com/dialing-codes/French%20Southern%20Territories-country-code.php

**South Georgia and the South Sandwich Islands**
https://en.wikipedia.org/wiki/Telephone_numbers_in_South_Georgia_and_the_South_Sandwich_Islands

**Bouvet Island**
https://www.distancelatlong.com/countrycode/of/bouvet-island/
https://en.wikipedia.org/wiki/Bouvet_Island
About that, there are some conflicting informations about the country phone prefix (some sites say +47, some +55), it seems that beeing considered Norwegian territory should have +47